### PR TITLE
Fixed PacMan tests to be split into two test functions instead of one

### DIFF
--- a/Projects/P2/app/src/test/java/pacman/TestPacManConsume.java
+++ b/Projects/P2/app/src/test/java/pacman/TestPacManConsume.java
@@ -11,10 +11,17 @@ public class TestPacManConsume extends TestCase {
   public void testPacManConsume() throws FileNotFoundException {
     NoFrame frame = new NoFrame();
     PacMan pacmanCookie = frame.addPacMan(new Location(2, 1));
+
+    Assert.assertNull(pacmanCookie.consume());
+
+    return;
+  } 
+
+  public void testPacManNoConsume() throws FileNotFoundException {
+    NoFrame frame = new NoFrame();
     PacMan pacmanNoCookie = frame.addPacMan(new Location(13, 9));
 
     Assert.assertNull(pacmanCookie.consume());
-    Assert.assertNull(pacmanNoCookie.consume());
 
     return;
   } 


### PR DESCRIPTION
Originally, the tests had two PacMans in one test case. However, PacMan objects all have the same name, so this may create an issue when testing two of them in the same function and expecting different results. Fixed and committed the necessary changes.